### PR TITLE
Fixing template

### DIFF
--- a/xteve.xml
+++ b/xteve.xml
@@ -34,7 +34,7 @@
   <Data>
     <Volume>
       <HostDir>/mnt/user/appdata/xteve</HostDir>
-      <ContainerDir>/root/xteve</ContainerDir>
+      <ContainerDir>/root/.xteve</ContainerDir>
       <Mode>rw</Mode>
     </Volume>
     <Volume>


### PR DESCRIPTION
Missing VITAL dot
refference: https://github.com/bl0m1/xtevedocker#usage-for-running-on-host